### PR TITLE
Add cpdNamespace as a configuration parameter that must be set

### DIFF
--- a/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
@@ -5,7 +5,9 @@
 ####
 palantirOperatorNamespace: "palantir"
 ####
-# `cpdNamespace` is the name of the namespace in which Cloud Pak for Data is installed.
+# `cpdNamespace` is the OpenShift namespace in which Cloud Pak for Data is installed.
+# This should be the same $CPD_NAMESPACE value that is provided to the `cpd-cli` commands during the
+# installation process.
 ####
 cpdNamespace: ""
 ####

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
@@ -28,6 +28,10 @@ proxyPrivateKeyBase64: ""
 ####
 instanceName: ""
 ####
+# `cpdNamespace` is the name of in which Cloud Pak for Data is installed.
+####
+cpdNamespace: ""
+####
 # `imageRegistryPrefix` is the container registry FQDN the palantir-operator will use when 
 # installing P4CP4D. 
 ####

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
@@ -28,7 +28,7 @@ proxyPrivateKeyBase64: ""
 ####
 instanceName: ""
 ####
-# `cpdNamespace` is the name of in which Cloud Pak for Data is installed.
+# `cpdNamespace` is the name of the namespace in which Cloud Pak for Data is installed.
 ####
 cpdNamespace: ""
 ####

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/install-override.yaml
@@ -5,6 +5,10 @@
 ####
 palantirOperatorNamespace: "palantir"
 ####
+# `cpdNamespace` is the name of the namespace in which Cloud Pak for Data is installed.
+####
+cpdNamespace: ""
+####
 # `cp4dFQDN` is the fully qualified domain name of the Cloud Pak for Data instance for which 
 # P4CP4D should integrate with
 ####
@@ -27,10 +31,6 @@ proxyPrivateKeyBase64: ""
 # this value as an empty string, however the field must still exist
 ####
 instanceName: ""
-####
-# `cpdNamespace` is the name of the namespace in which Cloud Pak for Data is installed.
-####
-cpdNamespace: ""
 ####
 # `imageRegistryPrefix` is the container registry FQDN the palantir-operator will use when 
 # installing P4CP4D. 

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -33,7 +33,7 @@ data:
         selector:
           rubix-app: envoy
       image-registry-prefix: {{ .imageRegistryPrefix }}
-      cpd-namespace: {{ .cpdNmespace }}
+      cpd-namespace: {{ .cpdNamespace }}
       storage-class: {{ .storageClass }}
       application-class: small
     applications:

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -36,43 +36,6 @@ data:
       cpd-namespace: {{ .cpdNamespace }}
       storage-class: {{ .storageClass }}
       application-class: small
-    applications:
-    - name: vault-deployment
-      version: 2.84.1
-    - name: vault-etcd
-      version: 3.4.517
-    - name: launchcontrol-deployment
-      version: 1.85.1
-    - name: launchpod
-      version: 1.17.0
-    - name: rubix-auth-deployment
-      version: 1.117.1
-    - name: configuration-renderer
-      version: 1.61.0
-    - name: witchcraft-service-operator
-      version: 1.69.0
-    - name: discovery-generator
-      version: 1.41.0
-    - name: generated-secret-controller
-      version: 1.25.0
-    - name: rollout-controller
-      version: 1.25.0
-    - name: envoy-deployment
-      version: 1.25.0
-    - name: user-credential-manager
-      version: 0.1.33
-    - name: mesh-control-plane
-      version: 1.32.0
-    - name: ingress-manager
-      version: 1.24.0
-    - name: k8s-service-manager
-      version: 1.19.0
-    - name: status-sidecar-mutator
-      version: 1.43.2
-    - name: expected-state
-      version: 1.68.0
-    - name: injected-mesh-sidecar
-      version: 1.16.3
   runtime.yml: |
     logging:
       level: debug

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -33,6 +33,7 @@ data:
         selector:
           rubix-app: envoy
       image-registry-prefix: {{ .imageRegistryPrefix }}
+      cpd-namespace: {{ .cpdNmespace }}
       storage-class: {{ .storageClass }}
       application-class: small
     applications:

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -53,7 +53,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:0.5.1"
+          image: "docker.external.palantir.build/deployability/palantir-operator:0.5.2"
           imagePullPolicy: Always
           securityContext:
             privileged: false


### PR DESCRIPTION
- Add cpdNamespace as a configuration parameter that must be set
- Bump image to 0.5.2
- Remove application specification that is no longer read

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

