### PR TITLE
Add environment variables for logging

### DIFF
--- a/changelog/@unreleased/pr-46.v2.yml
+++ b/changelog/@unreleased/pr-46.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add environment variables for logging
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/46

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -86,6 +86,28 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: LOG_ENVELOPE_SERVICE_NAME
+              value: palantir-operator
+            - name: LOG_ENVELOPE_SERVICE_ID
+              value: palantir-operator
+            - name: LOG_ENVELOPE_STACK_NAME
+              value: palantir
+            - name: LOG_ENVELOPE_STACK_ID
+              value: palantir
+            - name: LOG_ENVELOPE_PRODUCT_NAME
+              value: palantir-operator
+            - name: LOG_ENVELOPE_PRODUCT_VERSION
+              value: 1.0.3
+            - name: LOG_ENVELOPE_HOST
+              valuefrom:
+                fieldref:
+                  apiversion: v1
+                  fieldpath: spec.nodeName
+            - name: LOG_ENVELOPE_NODE_ID
+              valuefrom:
+                fieldref:
+                  apiversion: v1
+                  fieldpath: metadata.name
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Before this PR
Palantir Operator is missing the environment variables necessary for logs to be correctly tagged upstream.

## After this PR
Adds the missing environment variables. Some environment variables are also set programmatically at runtime. 
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

