### PR TITLE
Revert "Add environment variables for logging"

### DIFF
--- a/changelog/@unreleased/pr-46.v2.yml
+++ b/changelog/@unreleased/pr-46.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Add environment variables for logging
-  links:
-  - https://github.com/palantir/palantir-cloudpak/pull/46

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -86,28 +86,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: LOG_ENVELOPE_SERVICE_NAME
-              value: palantir-operator
-            - name: LOG_ENVELOPE_SERVICE_ID
-              value: palantir-operator
-            - name: LOG_ENVELOPE_STACK_NAME
-              value: palantir
-            - name: LOG_ENVELOPE_STACK_ID
-              value: palantir
-            - name: LOG_ENVELOPE_PRODUCT_NAME
-              value: palantir-operator
-            - name: LOG_ENVELOPE_PRODUCT_VERSION
-              value: 1.0.3
-            - name: LOG_ENVELOPE_HOST
-              valuefrom:
-                fieldref:
-                  apiversion: v1
-                  fieldpath: spec.nodeName
-            - name: LOG_ENVELOPE_NODE_ID
-              valuefrom:
-                fieldref:
-                  apiversion: v1
-                  fieldpath: metadata.name
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Reverts palantir/palantir-cloudpak#46

The env vars are injected by a mutating webhook.