### PR TITLE
Add InsecureSkipVerify annotation to pod template

### DIFF
--- a/changelog/@unreleased/pr-48.v2.yml
+++ b/changelog/@unreleased/pr-48.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add InsecureSkipVerify annotation to pod template
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/48

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        com.palantir.deployability/status-sidecar-insecure-skip-verify: ""
         com.palantir.rubix.pod/sls-service-info-v2: >
           {
             "service-name": "palantir-operator",


### PR DESCRIPTION
## Before this PR
This [PR](https://github.com/palantir/palantir-cloudpak/pull/40) adds annotations so that sls-status-sidecar gets injected. However, the sidecar will not be able to establish a trusted connection with the main container because it uses self-signed certs. 
## After this PR
Add an annotation so that the status probe client used by the injected sidecar skips verification of server certs.
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

