### PR TITLE
improvement: add a dedicated ConfigMap for user-defined preferences

### DIFF
--- a/changelog/@unreleased/pr-57.v2.yml
+++ b/changelog/@unreleased/pr-57.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add a dedicated ConfigMap for user-defined preferences that is not
+    affected by automatic upgrades of palantir-operator.
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/57

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/main.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/main.yaml
@@ -8,5 +8,6 @@ images:
 templateModuleFiles:
   - name: palantir-operator.yaml
   - name: palantir-operator-configmap.yaml
+  - name: palantir-operator-user-config.yaml
 
 installOverride: install-override.yaml

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -42,6 +42,12 @@ data:
       cpd-namespace: {{ .cpdNamespace }}
       storage-class: {{ .storageClass }}
       application-class: small
+      namespace-config:
+        infrastructure: palantir-cloudpak-infrastructure
+        services: palantir-cloudpak-services
+        data: palantir-cloudpak-data
+        compute-spark: palantir-cloudpak-compute-spark
+        compute-misc: palantir-cloudpak-compute-misc
   runtime.yml: |
     logging:
       level: info

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
@@ -1,0 +1,28 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: palantir-operator
+    app.kubernetes.io/managed-by: palantir.com
+    app.kubernetes.io/instance: palantir-operator
+  name: palantir-operator-user-config
+data:
+  userconfig.yml: |
+    artifactory-creds:
+      src-secret: docker-pull-{{ .palantirOperatorNamespace }}-docker-external-palantir-build-base-registry-registry
+      dst-secret: palantir-ext-creds
+    cpd-namespace: {{ .cpdNamespace }}
+    disable-firewalls: {{ .disableFirewalls }}
+    registration-config-secret: registration-info
+    data-storage:
+      path: {{ .dataStoragePath }}
+      endpoint: {{ .dataStorageEndpoint }}
+      creds-secret: data-storage-creds
+      encryption-secret: data-storage-encryption
+    frontdoor-config:
+      base-domain: {{ .cp4dFQDN }}
+      base-64-cert: {{ .proxyCertificateBase64 }}
+      base-64-key: {{ .proxyPrivateKeyBase64 }}
+    image-registry-prefix: {{ .imageRegistryPrefix }}
+    instance-name: {{ .instanceName }}
+    storage-class: {{ .storageClass }}

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
@@ -13,7 +13,6 @@ data:
       dst-secret: palantir-ext-creds
     cpd-namespace: {{ .cpdNamespace }}
     disable-firewalls: {{ .disableFirewalls }}
-    registration-config-secret: registration-info
     data-storage:
       path: {{ .dataStoragePath }}
       endpoint: {{ .dataStorageEndpoint }}
@@ -25,4 +24,5 @@ data:
       base-64-key: {{ .proxyPrivateKeyBase64 }}
     image-registry-prefix: {{ .imageRegistryPrefix }}
     instance-name: {{ .instanceName }}
+    registration-config-secret: registration-info
     storage-class: {{ .storageClass }}

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.12.0",
+        "productVersion": "1.16.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.12.0"
+                "product-version": "1.16.0"
               }
             }
           }
@@ -89,7 +89,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.12.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.16.0"
           imagePullPolicy: Always
           securityContext:
             privileged: false


### PR DESCRIPTION
## Before this PR
User-defined preferences are rendered into the ConfigMap used for palantir-operator's install config. As we enable automatic upgrades of palantir-operator installations, this ConfigMap will become managed and changes to palantir-operator product could clobber these user-defined preferences. We can instead create a dedicated ConfigMap for user-defined preferences, which will not be managed when enabling automatic upgrades of palantir-operator. User-defined properties will be removed from `palantir-operator-configmap` in a subsequent PR after the migration is complete.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add a dedicated ConfigMap for user-defined preferences that is not affected by automatic upgrades of palantir-operator.
==COMMIT_MSG==

## Possible downsides?
N/A

