### PR TITLE
improvement: enquote optional user pref to preserve yaml formatting

### DIFF
--- a/changelog/@unreleased/pr-58.v2.yml
+++ b/changelog/@unreleased/pr-58.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Use the empty string as the default value for optional, user-defined
+    prefs.
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/58

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -26,7 +26,7 @@ data:
         src-secret: docker-pull-{{ .palantirOperatorNamespace }}-docker-external-palantir-build-base-registry-registry
         dst-secret: palantir-ext-creds
       own-namespace-env-var: OPERATOR_NAMESPACE
-      instance-name: {{ .instanceName }}
+      instance-name: "{{ .instanceName }}"
       frontdoor-config:
         base-domain: {{ .cp4dFQDN }}
         base-64-cert: {{ .proxyCertificateBase64 }}

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-user-config.yaml
@@ -23,6 +23,6 @@ data:
       base-64-cert: {{ .proxyCertificateBase64 }}
       base-64-key: {{ .proxyPrivateKeyBase64 }}
     image-registry-prefix: {{ .imageRegistryPrefix }}
-    instance-name: {{ .instanceName }}
+    instance-name: "{{ .instanceName }}"
     registration-config-secret: registration-info
     storage-class: {{ .storageClass }}


### PR DESCRIPTION
## Before this PR
The `instanceName` user-defined property is empty by default and isn't a required property. When the templated config map is rendered, this results in a yaml property without a corresponding value. When this happens, k8s escapes and enquotes the entire install.yml property, reducing readability. Instead, the optional pref should default to an empty, quoted string.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use the empty string as the default value for optional, user-defined prefs.
==COMMIT_MSG==

## Possible downsides?
N/A

