### PR TITLE
improvement: remove stale user-defined prefs; upgrade palantir-operator

### DIFF
--- a/changelog/@unreleased/pr-59.v2.yml
+++ b/changelog/@unreleased/pr-59.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump palantir-operator version and remove stale user-defined configuration.
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/59

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator-configmap.yaml
@@ -15,22 +15,7 @@ data:
       port: 3756
       context-path: /palantir-operator
     cluster-config:
-      disable-firewalls: {{ .disableFirewalls }}
-      registration-config-secret: registration-info
-      data-storage:
-        path: {{ .dataStoragePath }}
-        endpoint: {{ .dataStorageEndpoint }}
-        creds-secret: data-storage-creds
-        encryption-secret: data-storage-encryption
-      artifactory-creds:
-        src-secret: docker-pull-{{ .palantirOperatorNamespace }}-docker-external-palantir-build-base-registry-registry
-        dst-secret: palantir-ext-creds
       own-namespace-env-var: OPERATOR_NAMESPACE
-      instance-name: "{{ .instanceName }}"
-      frontdoor-config:
-        base-domain: {{ .cp4dFQDN }}
-        base-64-cert: {{ .proxyCertificateBase64 }}
-        base-64-key: {{ .proxyPrivateKeyBase64 }}
       envoy-service-spec:
         ports:
         - port: 6443
@@ -38,9 +23,6 @@ data:
           protocol: TCP
         selector:
           rubix-app: envoy
-      image-registry-prefix: {{ .imageRegistryPrefix }}
-      cpd-namespace: {{ .cpdNamespace }}
-      storage-class: {{ .storageClass }}
       application-class: small
       namespace-config:
         infrastructure: palantir-cloudpak-infrastructure

--- a/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
+++ b/cpd/modules/palantir-operator/x86_64/1.0.0/palantir-operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.16.0",
+        "productVersion": "1.18.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.16.0"
+                "product-version": "1.18.0"
               }
             }
           }
@@ -89,7 +89,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.16.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.18.0"
           imagePullPolicy: Always
           securityContext:
             privileged: false


### PR DESCRIPTION
## Before this PR
Stale user-defined configuration existed in palantir-operator's install.yml while it was manually migrated after the change made in https://github.com/palantir/palantir-cloudpak/pull/57. These user-defined preferences are no longer referenced and can be safely removed.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Bump palantir-operator version and remove stale user-defined configuration.
==COMMIT_MSG==

## Possible downsides?
N/A

