### PR TITLE
fix: remove dangling role_binding.yaml ref

### DIFF
--- a/changelog/@unreleased/pr-62.v2.yml
+++ b/changelog/@unreleased/pr-62.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The repo no longer has a reference to a nonexistent role binding
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/62

--- a/cpd/modules/palantir-operator-adm/x86_64/1.0.0/main.yaml
+++ b/cpd/modules/palantir-operator-adm/x86_64/1.0.0/main.yaml
@@ -2,7 +2,6 @@ type: module
 category: adm-setup
 name: palantir-operator-adm
 files:
-- adm/role_binding.yaml
 - adm/role_binding_cpd.yaml
 - adm/role.yaml
 - adm/cluster_role.yaml


### PR DESCRIPTION
## Before this PR
The repo references a role binding that now longer exists (it was removed in https://github.com/palantir/palantir-cloudpak/pull/60).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The repo no longer has a reference to a nonexistent role binding
==COMMIT_MSG==

## Possible downsides?
N/A

