### PR TITLE
Change regex to match option v

### DIFF
--- a/case/palantir-operator/prereqs.yaml
+++ b/case/palantir-operator/prereqs.yaml
@@ -8,7 +8,7 @@ prereqs:
       oc:
         command: "oc"
         versionArgs: "version"
-        versionRegex: "Client Version: v4.\\d+"
+        versionRegex: "Client Version: v?4.\\d+"
     k8sResources:
       workerIntelLinux:
         kind: Node


### PR DESCRIPTION
## Before this PR
Doesn't match client versions in the form `Client Version: 4.7.12`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Match an option v in the client version text
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

