### PR TITLE
improvement: update user-config with new cpd domain preferences

### DIFF
--- a/changelog/@unreleased/pr-72.v2.yml
+++ b/changelog/@unreleased/pr-72.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: update user-config with new cpd domain preferences
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/72

--- a/palantir-operator/inventory/palantir-operator/files/operator.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.27.0",
+        "productVersion": "1.49.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.27.0"
+                "product-version": "1.49.0"
               }
             }
           }
@@ -69,7 +69,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.27.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.49.0"
           imagePullPolicy: Always
           env:
             - name: OPERATOR_NAMESPACE

--- a/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
@@ -12,6 +12,7 @@ data:
       src-secret: palantir-ext-creds
       dst-secret: palantir-ext-creds
     cpd-namespace: #CPD_NAMESPACE#
+    cpd-domain: #CPD_DOMAIN#
     disable-firewalls: #DISABLE_NETWORK_FIREWALLS#
     data-storage:
       path: #DATA_STORAGE_PATH#
@@ -20,6 +21,7 @@ data:
       encryption-secret: data-storage-encryption
     frontdoor-config:
       base-domain: #CPD_DOMAIN#
+      domain: palantir-cloudpak.#CPD_DOMAIN#
       cert-secret:  proxy-certificate
     image-registry-prefix: docker.external.palantir.build
     registration-config-secret: registration-info


### PR DESCRIPTION
## Before this PR
The user-config ConfigMap resource yaml does not specify the new `cpd-domain` and `frontdoor-config.domain` preferences that are replacing `frontdoor-config.base-domain`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
update user-config with new cpd domain preferences
==COMMIT_MSG==

## Possible downsides?
N/A

