### PR TITLE
improvement: remove unused, deprecated pref from user config

### DIFF
--- a/changelog/@unreleased/pr-73.v2.yml
+++ b/changelog/@unreleased/pr-73.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: remove unused, deprecated pref from user config and bump palantir-operator
+    version
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/73

--- a/palantir-operator/inventory/palantir-operator/files/operator.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.49.0",
+        "productVersion": "1.50.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.49.0"
+                "product-version": "1.50.0"
               }
             }
           }
@@ -69,7 +69,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.49.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.50.0"
           imagePullPolicy: Always
           env:
             - name: OPERATOR_NAMESPACE

--- a/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
@@ -20,7 +20,6 @@ data:
       creds-secret: data-storage-creds
       encryption-secret: data-storage-encryption
     frontdoor-config:
-      base-domain: #CPD_DOMAIN#
       domain: palantir-cloudpak.#CPD_DOMAIN#
       cert-secret:  proxy-certificate
     image-registry-prefix: docker.external.palantir.build


### PR DESCRIPTION
## Before this PR
An unused config pref was specified in user config.

## After this PR
==COMMIT_MSG==
remove unused, deprecated pref from user config and bump palantir-operator version
==COMMIT_MSG==

## Possible downsides?
N/A

