### PR TITLE
improvement: add namespace-prefix pref to userconfig and bump palantir-operator version

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: add namespace-prefix pref to userconfig and bump palantir-operator
+    version
+  links:
+  - https://github.com/palantir/palantir-cloudpak/pull/74

--- a/palantir-operator/inventory/palantir-operator/files/operator.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.53.0",
+        "productVersion": "1.55.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.53.0"
+                "product-version": "1.55.0"
               }
             }
           }
@@ -69,7 +69,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.53.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.55.0"
           imagePullPolicy: Always
           env:
             - name: OPERATOR_NAMESPACE

--- a/palantir-operator/inventory/palantir-operator/files/operator.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/operator.yaml
@@ -13,7 +13,7 @@ metadata:
         "entityId": "palantir-operator",
         "entityName": "palantir-operator",
         "productName": "palantir-operator",
-        "productVersion": "1.50.0",
+        "productVersion": "1.53.0",
         "productGroup": "com.palantir.deployability",
         "stackName": "palantir-operator",
         "stackId": "palantir-operator"
@@ -45,7 +45,7 @@ spec:
             "containers": {
               "palantir-operator": {
                 "product-name": "palantir-operator",
-                "product-version": "1.50.0"
+                "product-version": "1.53.0"
               }
             }
           }
@@ -69,7 +69,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: palantir-operator
-          image: "docker.external.palantir.build/deployability/palantir-operator:1.50.0"
+          image: "docker.external.palantir.build/deployability/palantir-operator:1.53.0"
           imagePullPolicy: Always
           env:
             - name: OPERATOR_NAMESPACE

--- a/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
+++ b/palantir-operator/inventory/palantir-operator/files/userconfig.yaml
@@ -23,5 +23,6 @@ data:
       domain: palantir-cloudpak.#CPD_DOMAIN#
       cert-secret:  proxy-certificate
     image-registry-prefix: docker.external.palantir.build
+    namespace-prefix: palantir-cloudpak
     registration-config-secret: registration-info
     storage-class: #STORAGE_CLASS#


### PR DESCRIPTION
## Before this PR
New installs don't specify the `namespace-prefix` property that should be specified.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add namespace-prefix pref to userconfig and bump palantir-operator version
==COMMIT_MSG==

## Possible downsides?
N/A

